### PR TITLE
fixes to support conan 1.50.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ A conan wrapper for https://github.com/felix-org/armadillo-code
 
 To add Armadillo to your conan cache:
 ```sh
-$ conan create . user/channel -s cppstd=14
+
+conan create . -s compiler.cppstd=14 --build missing
+
 ```
+
 
 #### Dependencies
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+conan create . -s compiler.cppstd=14 --build missing
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+  conan create . --build missing --profile:build profiles/macos-profile --profile:host profiles/android-armv7-profile
+  conan create . --build missing --profile:build profiles/macos-profile --profile:host profiles/android-armv8-profile
+else
+  echo 'Cross-building profiles only provided for macOS.'
+fi

--- a/profiles/android-armv7-profile
+++ b/profiles/android-armv7-profile
@@ -1,0 +1,16 @@
+[settings]
+os=Android
+os.api_level=21
+
+arch=armv7
+
+compiler=clang
+compiler.libcxx=libc++
+compiler.version=9
+
+build_type=Release
+
+[options]
+
+[build_requires]
+*: android-ndk/r21d

--- a/profiles/android-armv8-profile
+++ b/profiles/android-armv8-profile
@@ -1,0 +1,16 @@
+[settings]
+os=Android
+os.api_level=21
+
+arch=armv8
+
+compiler=clang
+compiler.libcxx=libc++
+compiler.version=9
+
+build_type=Release
+
+[options]
+
+[build_requires]
+*: android-ndk/r21d

--- a/profiles/macos-profile
+++ b/profiles/macos-profile
@@ -1,0 +1,16 @@
+[settings]
+arch=x86_64
+arch_build=x86_64
+build_type=Release
+compiler=apple-clang
+compiler.libcxx=libc++
+compiler.version=9.0
+compiler.cppstd=14
+os=Macos
+os_build=Macos
+
+[options]
+
+[build_requires]
+
+[env]


### PR DESCRIPTION
Adds build script and profiles to support cross-building from MacOS to Android for conan version 1.50.0